### PR TITLE
Make the single tags match the html 5 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ element per line and two spaces of indentation.
 
 This behavior can be controlled by the `__pretty` (default: `True` except for
 certain element types like `pre`) attribute when creating an element, and by
-the `pretty` (default: `True`) and `indent` (default: `  `) arguments to
-`render()`. Rendering options propagate to all descendant nodes.
+the `pretty` (default: `True`), `indent` (default: `  `) and `xhtml` (default: `False`)
+ arguments to `render()`. Rendering options propagate to all descendant nodes.
 
 ```python
 a = div(span('Hello World'))
@@ -322,6 +322,25 @@ print(a.render())
 ```
 ```html
 <div><span>Hello World</span></div>
+```
+```python
+d = div()
+with d:
+    hr()
+    p("Test")
+    br()
+print(d.render())
+print(d.render(xhtml=True))
+```
+```html
+<div>
+  <hr>
+  <p>Test</p><br>
+</div>
+<div>
+  <hr />
+  <p>Test</p><br />
+</div>
 ```
 
 

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -306,11 +306,11 @@ class dom_tag(object):
     return self.render()
   __str__ = __unicode__
 
-  def render(self, indent='  ', pretty=True):
-    data = self._render([], 0, indent, pretty)
+  def render(self, indent='  ', pretty=True, xhtml=False):
+    data = self._render([], 0, indent, pretty, xhtml)
     return u''.join(data)
 
-  def _render(self, sb, indent_level, indent_str, pretty):
+  def _render(self, sb, indent_level, indent_str, pretty, xhtml):
     pretty = pretty and self.is_pretty
 
     t = type(self)
@@ -328,10 +328,10 @@ class dom_tag(object):
     for attribute, value in sorted(self.attributes.items()):
       sb.append(' %s="%s"' % (attribute, escape(unicode(value), True)))
 
-    sb.append(' />' if self.is_single else '>')
+    sb.append(' />' if self.is_single and xhtml else '>')
 
     if not self.is_single:
-      inline = self._render_children(sb, indent_level + 1, indent_str, pretty)
+      inline = self._render_children(sb, indent_level + 1, indent_str, pretty, xhtml)
 
       if pretty and not inline:
         sb.append('\n')
@@ -344,7 +344,7 @@ class dom_tag(object):
 
     return sb
 
-  def _render_children(self, sb, indent_level, indent_str, pretty):
+  def _render_children(self, sb, indent_level, indent_str, pretty, xhtml):
     inline = True
     for child in self.children:
       if isinstance(child, dom_tag):
@@ -352,7 +352,7 @@ class dom_tag(object):
           inline = False
           sb.append('\n')
           sb.append(indent_str * indent_level)
-        child._render(sb, indent_level, indent_str, pretty)
+        child._render(sb, indent_level, indent_str, pretty, xhtml)
       else:
         sb.append(unicode(child))
 

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -328,7 +328,7 @@ class dom_tag(object):
     for attribute, value in sorted(self.attributes.items()):
       sb.append(' %s="%s"' % (attribute, escape(unicode(value), True)))
 
-    sb.append('>')
+    sb.append(' />' if self.is_single else '>')
 
     if not self.is_single:
       inline = self._render_children(sb, indent_level + 1, indent_str, pretty)

--- a/dominate/tags.py
+++ b/dominate/tags.py
@@ -1005,7 +1005,7 @@ class comment(html_tag):
   # Valid values are 'hidden', 'downlevel' or 'revealed'
   ATTRIBUTE_DOWNLEVEL = 'downlevel'
 
-  def _render(self, sb, indent_level=1, indent_str='  ', pretty=True):
+  def _render(self, sb, indent_level=1, indent_str='  ', pretty=True, xhtml=False):
     has_condition = comment.ATTRIBUTE_CONDITION in self.attributes
     is_revealed   = comment.ATTRIBUTE_DOWNLEVEL in self.attributes and \
         self.attributes[comment.ATTRIBUTE_DOWNLEVEL] == 'revealed'
@@ -1016,7 +1016,7 @@ class comment(html_tag):
     if has_condition:
       sb.append('[if %s]>' % self.attributes[comment.ATTRIBUTE_CONDITION])
 
-    pretty = self._render_children(sb, indent_level - 1, indent_str, pretty)
+    pretty = self._render_children(sb, indent_level - 1, indent_str, pretty, xhtml)
 
     # if len(self.children) > 1:
     if any(isinstance(child, dom_tag) for child in self):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -176,9 +176,9 @@ def test_raw():
   from dominate.util import raw
   d = div()
   with d:
-    raw('Hello World<br />')
+    raw('Hello World<br>')
 
-  assert d.render() == '''<div>Hello World<br /></div>'''
+  assert d.render() == '''<div>Hello World<br></div>'''
 
 
 def test_escape():
@@ -273,8 +273,24 @@ def test_pretty():
     '''<div><span>hi</span><span>there</span></div>'''
 
   assert span('hi', br(), 'there').render() == \
-      '''<span>hi<br />there</span>'''
+      '''<span>hi<br>there</span>'''
 
   assert span('hi', br(__inline=False), 'there').render() == \
-      '''<span>hi\n  <br />there\n</span>'''
+      '''<span>hi\n  <br>there\n</span>'''
+
+
+def test_xhtml():
+  assert head(script('foo'), style('bar')).render(xhtml=True) == '''<head>
+  <script>foo</script>
+  <style>bar</style>
+</head>'''
+
+  assert span('hi', br(), 'there').render(xhtml=True) == \
+         '''<span>hi<br />there</span>'''
+
+  assert span('hi', br(), 'there').render() == \
+         '''<span>hi<br>there</span>'''
+
+  assert span('hi', br(), 'there').render(xhtml=False) == \
+         '''<span>hi<br>there</span>'''
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -273,8 +273,8 @@ def test_pretty():
     '''<div><span>hi</span><span>there</span></div>'''
 
   assert span('hi', br(), 'there').render() == \
-      '''<span>hi<br>there</span>'''
+      '''<span>hi<br />there</span>'''
 
   assert span('hi', br(__inline=False), 'there').render() == \
-      '''<span>hi\n  <br>there\n</span>'''
+      '''<span>hi\n  <br />there\n</span>'''
 


### PR DESCRIPTION
Current version br() -->  "\<br>"
Proposed fix br() --> "\<br />"

Note: I haven't bumped the version number...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knio/dominate/80)
<!-- Reviewable:end -->
