### PR TITLE
Exclude compiled byte code from distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include README.md
 include LICENSE.txt
 recursive-include tests *
+global-exclude __pycache__
+global-exclude *.pyc


### PR DESCRIPTION
Hi, the current PyPI tarball contains a `__pycache__` folder, this causes tests to fail:
```
import file mismatch:
imported module 'test_utils' has this __file__ attribute:
  /home/tom/Docs/Programming/dominate/tests/test_utils.py
which is not the same as the test file we want to collect:
  /var/tmp/portage/dev-python/dominate-2.3.0/work/dominate-2.3.0/tests/test_utils.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```