### PR TITLE
Prevent escaping of '&' character when dealing with href attribute.

### DIFF
--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -326,7 +326,13 @@ class dom_tag(object):
     sb.append(name)
 
     for attribute, value in sorted(self.attributes.items()):
-      sb.append(' %s="%s"' % (attribute, escape(unicode(value), True)))
+      # No "&" escaping for href in order to prevent altering urls
+      escaped_value = escape(
+        unicode(value),
+        quote=True,
+        ampersand=attribute != 'href')
+      sb.append(' %s="%s"' % (attribute, escaped_value))
+        
 
     sb.append(' />' if self.is_single and xhtml else '>')
 

--- a/dominate/util.py
+++ b/dominate/util.py
@@ -51,16 +51,20 @@ def system(cmd, data=None):
   return out.decode('utf8')
 
 
-def escape(data, quote=True):  # stoled from std lib cgi
+# stoled from std lib cgi and modified to handle "&" char for urls
+def escape(data, quote=True, ampersand=True):
   '''
   Escapes special characters into their html entities
-  Replace special characters "&", "<" and ">" to HTML-safe sequences.
+  Replace special characters "<" and ">" to HTML-safe sequences.
   If the optional flag quote is true, the quotation mark character (")
+  is also translated.
+  If the optional flag ampersand is true, the ampersand character (&)
   is also translated.
 
   This is used to escape content that appears in the body of an HTML cocument
   '''
-  data = data.replace("&", "&amp;")  # Must be done first!
+  if ampersand:
+    data = data.replace("&", "&amp;")  # Must be done first!
   data = data.replace("<", "&lt;")
   data = data.replace(">", "&gt;")
   if quote:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -227,6 +227,11 @@ def test_keyword_attributes():
   assert div(class_name='foo', html_for='bar').render() == expected
 
 
+def test_href_attribute():
+  expected = '<a href="https://test.org/aaa?a=b&c=d">toto</a>'
+  assert a('toto', href='https://test.org/aaa?a=b&c=d').render() == expected
+
+
 def test_comment():
   d = comment('Hi there')
   assert d.render() == '<!--Hi there-->'


### PR DESCRIPTION
- modify the util.escape function to handle separatly the & case following the " special case pattern
- add test to ensure the problem won't come back later

It should solve #96 