### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+    - pip install pip --upgrade
     - pip install pytest>=2.7.3 --upgrade
 
 # command to run tests, e.g. python setup.py test

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Output:
 Compatibility
 -------------
 
-`Dominate` is compatible with both Python 2.7 and Python 3.3. There are known issues with Python 3.2 and below.
+`Dominate` is compatible with both Python 2.7 and Python 3.4+.
 
 [![Build Status](https://travis-ci.org/Knio/dominate.png?branch=master)](https://travis-ci.org/Knio/dominate)
 [![Coverage Status](https://coveralls.io/repos/Knio/dominate/badge.png?branch=master)](https://coveralls.io/r/Knio/dominate?branch=master)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: Implementation :: PyPy',


### PR DESCRIPTION
Python 3.3 is EOL (since 2017-09-29) and no longer receiving security updates (or any updates) from the core Python team.

It's also little used.

Here's the pip installs for dominate from PyPI for August 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.6            |  45.11% |         26,193 |
| 2.7            |  27.62% |         16,039 |
| 3.5            |  14.32% |          8,315 |
| 3.7            |   7.63% |          4,431 |
| 3.4            |   4.95% |          2,872 |
| 3.3            |   0.28% |            161 |
| 2.6            |   0.09% |             51 |
| Total          |         |         58,062 |

Source: `pypinfo --start-date 2018-08-01 --end-date 2018-08-31 --markdown --percent dominate pyversion`

It is also failing the build (eg. see PR https://github.com/Knio/dominate/pull/100 which only changed the README) because dependencies no longer support Python 3.3.

This PR also upgrades pip which fixes the Python 3.4 build.

