### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -20,9 +20,16 @@ Public License along with Dominate.  If not, see
 
 import copy
 import numbers
-from collections import defaultdict, namedtuple, Callable
+from collections import defaultdict, namedtuple
 from functools import wraps
 import threading
+
+try:
+  # Python 3
+  from collections.abc import Callable
+except ImportError:
+  # Python 2.7
+  from collections import Callable
 
 try:
   basestring = basestring

--- a/dominate/util.py
+++ b/dominate/util.py
@@ -84,7 +84,7 @@ def unescape(data):
   '''
   unescapes html entities. the opposite of escape.
   '''
-  cc = re.compile('&(?:(?:#(\d+))|([^;]+));')
+  cc = re.compile(r'&(?:(?:#(\d+))|([^;]+));')
 
   result = []
   m = cc.search(data)


### PR DESCRIPTION
There are a couple of deprecation warnings on Python 3.7:

```
⌂112% [hugo:/tmp/dominate] master ± find . -name "*.pyc" -exec rm -f {} \;
⌂112% [hugo:/tmp/dominate] master ± pytest
================================================================ test session starts =================================================================
platform darwin -- Python 3.7.0, pytest-3.8.1, py-1.5.4, pluggy-0.7.1
rootdir: /private/tmp/dominate, inifile:
plugins: cov-2.5.1, flaky-3.4.0
collected 28 items

tests/test_document.py ....                                                                                                                    [ 14%]
tests/test_dom1core.py .                                                                                                                       [ 17%]
tests/test_html.py ...................                                                                                                         [ 85%]
tests/test_utils.py ....                                                                                                                       [100%]
===Flaky Test Report===


===End Flaky Test Report===

================================================================== warnings summary ==================================================================
/private/tmp/dominate/dominate/dom_tag.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import defaultdict, namedtuple, Callable

/private/tmp/dominate/dominate/util.py:87: DeprecationWarning: invalid escape sequence \d
  cc = re.compile('&(?:(?:#(\d+))|([^;]+));')

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================= 28 passed, 2 warnings in 0.39 seconds ========================================================
```

Changes proposed in this pull request:

 * Prefer `collections.abc` (new in [Python 3.3](https://docs.python.org/3.7/library/collections.abc.html)) over `collections` for abstract base classes
 * "In Python 3.8, the abstract base classes in `collections.abc` will no longer be exposed in the regular `collections` module. This will help create a clearer distinction between the concrete classes and the abstract base classes."
 * https://docs.python.org/3.7/whatsnew/3.7.html#deprecated
 * Declare the regex string as a raw string with `r` so the `\d` isn't treated as an escaped character

# After

```
⌂92% [hugo:/tmp/dominate] fix-deprecationwarnings ± find . -name "*.pyc" -exec rm -f {} \;
⌂87% [hugo:/tmp/dominate] fix-deprecationwarnings ± pytest
================================================================ test session starts =================================================================
platform darwin -- Python 3.7.0, pytest-3.8.1, py-1.5.4, pluggy-0.7.1
rootdir: /private/tmp/dominate, inifile:
plugins: cov-2.5.1, flaky-3.4.0
collected 28 items

tests/test_document.py ....                                                                                                                    [ 14%]
tests/test_dom1core.py .                                                                                                                       [ 17%]
tests/test_html.py ...................                                                                                                         [ 85%]
tests/test_utils.py ....                                                                                                                       [100%]
===Flaky Test Report===


===End Flaky Test Report===

============================================================= 28 passed in 0.41 seconds ==============================================================
```