### PR TITLE
Let PyPI know long_description is Markdown to format it nicely

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
 
   description      = 'Dominate is a Python library for creating and manipulating HTML documents using an elegant DOM API.',
   long_description = long_description,
+  long_description_content_type='text/markdown',
   keywords         = 'framework templating template html xhtml python html5',
 
   classifiers = [


### PR DESCRIPTION
The new version of PyPI (aka Warehouse) can now format Markdown properly, if it knows `long_description` is in that format.

You also need to upload with recent twine and setuptools (and wheel, if you use that) to send this new metadata:

pip install -U setuptools twine wheel

See https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi for more info.