### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
   - "3.6"
   - "pypy"
   - "pypy3"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
   long_description = long_description,
   keywords         = 'framework templating template html xhtml python html5',
 
+  python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
   classifiers = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
A little workaround is needed for Travis CI, as 3.7 needs Xenial and sudo. See https://github.com/travis-ci/travis-ci/issues/9815 for more info.

Also add `python_requires` to help pip know which version to install.

My last PR for now :)