### PR TITLE
 Suppress rendering of boolean attributes when the value is False

### DIFF
--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -333,7 +333,8 @@ class dom_tag(object):
     sb.append(name)
 
     for attribute, value in sorted(self.attributes.items()):
-      sb.append(' %s="%s"' % (attribute, escape(unicode(value), True)))
+      if value is not False: # False values must be omitted completely
+          sb.append(' %s="%s"' % (attribute, escape(unicode(value), True)))
 
     sb.append(' />' if self.is_single and xhtml else '>')
 
@@ -377,6 +378,7 @@ class dom_tag(object):
     if children_len != 1: children += 'ren'
 
     return '<%s at %x: %s, %s>' % (name, id(self), attributes, children)
+
 
   @staticmethod
   def clean_attribute(attribute):
@@ -425,8 +427,7 @@ class dom_tag(object):
     if value is True:
       value = attribute
 
-    if value is False:
-      value = "false"
+    # Ignore `if value is False`: this is filtered out in render()
 
     return (attribute, value)
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -195,9 +195,14 @@ def test_attributes():
     del d['id']
   with pytest.raises(AttributeError):
     x = d['id']
-  with d:
+
+  with div() as d:
     attr(data_test=False)
-  assert d['data-test'] == 'false'
+  assert d['data-test'] is False
+
+  with div() as d:
+    attr(data_test=True)
+  assert d['data-test']
 
   with pytest.raises(ValueError):
     attr(id='moo')
@@ -236,6 +241,13 @@ def test_comment():
   d = comment('Hi there')
   assert d.render() == '<!--Hi there-->'
   assert div(d).render() == '<div>\n  <!--Hi there-->\n</div>'
+
+
+def test_boolean_attributes():
+  assert input(type="checkbox", checked=True).render() == \
+      '<input checked="checked" type="checkbox">'
+  assert input(type="checkbox", checked=False).render() == \
+      '<input type="checkbox">'
 
 
 def test_nested_decorator_2():
@@ -298,4 +310,3 @@ def test_xhtml():
 
   assert span('hi', br(), 'there').render(xhtml=False) == \
          '''<span>hi<br>there</span>'''
-


### PR DESCRIPTION
> The values "true" and "false" are not allowed on boolean
> attributes. To represent a false value, the attribute has
> to be omitted altogether.

HTML 5.2, W3C Recommendation, 14 December 2017
https://www.w3.org/TR/html5/infrastructure.html#boolean-attribute

Expected behaviour is demonstrated by the included test case:

```
def test_boolean_attributes():
  assert input(type="checkbox", checked=True).render() == \
      '<input checked="checked" type="checkbox">'
  assert input(type="checkbox", checked=False).render() == \
      '<input type="checkbox">'
```