### PR TITLE
html_tag: create hyphenate_tagname attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,3 +581,29 @@ print(circle(stroke_width=5))
 <circle stroke-width="5"></circle>
 ```
 
+Custom Tags
+-----------
+Custom tags, such as those used by Vue.js, can be created by overriding `html_tag`.
+
+Override the `hyphenate_tagname` attribute to replace underscores in the class name with hyphens.
+
+```python
+class vue_tag(html_tag):
+    hyphenate_tagname = True
+
+class v_app(vue_tag): pass
+class v_content(vue_tag): pass
+class v_container(vue_tag): pass
+
+print(div(v_app(v_content(v_container('Hello world'))), id='app'))
+```
+
+```html
+<div id="app">
+  <v-app>
+    <v-content>
+      <v-container>Hello world</v-container>
+    </v-content>
+  </v-app>
+</div>
+```

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -57,6 +57,9 @@ class dom_tag(object):
                      # modified
   is_inline = False
 
+  # Replace underscores in tag name with hyphens
+  hyphenate_tagname = False
+
   frame = namedtuple('frame', ['tag', 'items', 'used'])
 
   def __new__(_cls, *args, **kwargs):
@@ -313,6 +316,12 @@ class dom_tag(object):
     return self.render()
   __str__ = __unicode__
 
+  @property
+  def _name(self):
+    t = type(self)
+    n = getattr(t, 'tagname', t.__name__)
+    return n.replace('_', '-') if self.hyphenate_tagname else n
+
   def render(self, indent='  ', pretty=True, xhtml=False):
     data = self._render([], 0, indent, pretty, xhtml)
     return u''.join(data)
@@ -320,11 +329,9 @@ class dom_tag(object):
   def _render(self, sb, indent_level, indent_str, pretty, xhtml):
     pretty = pretty and self.is_pretty
 
-    t = type(self)
-    name = getattr(t, 'tagname', t.__name__)
-
     # Workaround for python keywords and standard classes/methods
     # (del, object, input)
+    name = self._name
     if name[-1] == '_':
       name = name[:-1]
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -295,6 +295,13 @@ def test_pretty():
   assert span('hi', br(__inline=False), 'there').render() == \
       '''<span>hi\n  <br>there\n</span>'''
 
+def test_hyphenate_tagname():
+  class my_tag(html_tag):
+      hyphenate_tagname = True
+
+  d = my_tag(pre('test')).render(pretty=False) == \
+    '''<my-tag><pre>test</pre></my-tag>'''
+
 
 def test_xhtml():
   assert head(script('foo'), style('bar')).render(xhtml=True) == '''<head>


### PR DESCRIPTION
Python does not allow classes to be created with hyphenated names, and
it's convenient to be able to use the tag's Python class name for
rendering, rather than specifying an explicit tagname attribute for each
custom tag.

HTML allows hyphenated tag names, so add an attribute to `html_tag` to
replace underscores in the tag's Python class name with hyphens when enabled.

Closes #120 