### PR TITLE
Removed 'input' keyword reassignment, Fixes #128

### DIFF
--- a/dominate/tags.py
+++ b/dominate/tags.py
@@ -725,7 +725,7 @@ class del_(html_tag):
   The del element represents a removal from the document.
   '''
   pass
-
+_del = del_
 
 # Embedded content
 class img(html_tag):
@@ -814,7 +814,7 @@ class map_(html_tag):
   image map. The element represents its children.
   '''
   pass
-
+_map = map_
 
 class area(html_tag):
   '''
@@ -948,7 +948,7 @@ class input_(html_tag):
   to allow the user to edit the data.
   '''
   is_single = True
-input = _input = input_
+_input = input_
 
 
 class button(html_tag):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -244,9 +244,9 @@ def test_comment():
 
 
 def test_boolean_attributes():
-  assert input(type="checkbox", checked=True).render() == \
+  assert _input(type="checkbox", checked=True).render() == \
       '<input checked="checked" type="checkbox">'
-  assert input(type="checkbox", checked=False).render() == \
+  assert _input(type="checkbox", checked=False).render() == \
       '<input type="checkbox">'
 
 


### PR DESCRIPTION
Direct fix to #128.
Additionally, I've added the missing assignment for leading underscores for `del` and `map` as these only supported tailing underscores.