### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-
+arch:
+  - amd64
+  - ppc64le
 python:
   - "2.7"
   - "3.4"
@@ -9,7 +11,12 @@ python:
   - "3.8"
   - "pypy"
   - "pypy3"
-
+matrix:
+  exclude:
+     - python: "pypy"
+       arch: ppc64le
+     - python: "pypy3"
+       arch: ppc64le
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - pip install pip --upgrade


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/dominate/builds/187375894 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!