### PR TITLE
(chore) Add unit tests to untested methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
     - pip install pip --upgrade
     - pip install importlib_metadata --upgrade # fix for broken py3.7
     - pip install pytest>=2.7.3 --upgrade
+    - pip install mock --upgrade
 
 # command to run tests, e.g. python setup.py test
 script:

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -27,13 +27,13 @@ import threading
 try:
   # Python 3
   from collections.abc import Callable
-except ImportError:
+except ImportError: # pragma: no cover
   # Python 2.7
   from collections import Callable
 
 try:
   basestring = basestring
-except NameError: # py3
+except NameError: # py3 # pragma: no cover
   basestring = str
   unicode = str
 
@@ -265,7 +265,7 @@ class dom_tag(object):
       # Children are accessed using integers
       try:
         return object.__getattribute__(self, 'children')[key]
-      except KeyError:
+      except IndexError:
         raise IndexError('Child with index "%s" does not exist.' % key)
     elif isinstance(key, basestring):
       # Attributes are accessed using strings

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -110,6 +110,9 @@ def test_attributes():
   <body></body>
 </html>'''
 
+def test_repr():
+  d = document(title='foo')
+  assert d.__repr__() == '<dominate.document "foo">'
 
 if __name__ == '__main__':
   # test_doc()

--- a/tests/test_dom1core.py
+++ b/tests/test_dom1core.py
@@ -13,9 +13,10 @@ def test_dom():
   assert container.getElementById('base') is dom
   assert container.getElementById('span1') is s1
   assert container.getElementById('span3') is s3
+  assert container.getElementById('foo') is None
   assert container.getElementsByTagName('span') == [s1, s2, s3]
   assert container.getElementsByTagName('SPAN') == [s1, s2, s3]
-
+  assert container.getElementsByTagName(1234) is None
 
 def test_element():
   d = div(
@@ -25,3 +26,9 @@ def test_element():
   with pytest.raises(ValueError):
     d.getElementById('a')
 
+def test_parent_node():
+  parent = div(id='parent')
+  child = div(id='child')
+  parent.add(child)
+
+  assert child.parentNode is parent

--- a/tests/test_dom_tag.py
+++ b/tests/test_dom_tag.py
@@ -1,0 +1,69 @@
+import mock
+import pytest
+
+from dominate.tags import *
+
+from dominate import dom_tag as sut
+
+def test___get_thread_context(monkeypatch):
+    greenlet = mock.Mock()
+    greenlet.getcurrent.return_value = 100
+    monkeypatch.setattr(sut, 'greenlet', greenlet)
+
+    threading = mock.Mock()
+    threading.current_thread.return_value = 200
+    monkeypatch.setattr(sut, 'threading', threading)
+
+    assert sut._get_thread_context() in [
+        -6805948436281256182, # Python >= 3.9
+        3713141171098444831, # Python < 3.9
+    ]
+
+def test_add_raw_string():
+    container = div()
+
+    container.add_raw_string('foo')
+
+    assert container.children == ['foo']
+
+def test_clear():
+    container = div()
+    child = div()
+
+    container.add(child)
+
+    assert container.children == [child]
+    assert child.parent == container
+
+    container.clear()
+
+    assert container.children == []
+    assert child.parent is None
+
+def test_set_attribute():
+    container = div()
+
+    container.add_raw_string('foo')
+    container.set_attribute(0, 'bar')
+
+    assert container.children == ['bar']
+
+def test_set_attribute_error():
+    container = div()\
+
+    with pytest.raises(TypeError, match=(
+            'Only integer and string types are valid for assigning '
+            'child tags and attributes, respectively.'
+        )):
+        container.set_attribute(1.0, 'foo')
+
+def test___get_item___child_index_error():
+    d = div()
+    with pytest.raises(IndexError, match='Child with index "10" does not exist.'):
+        d[10]
+
+def test___contains__():
+    container = div()
+    container.add(div())
+
+    assert 'div' in container


### PR DESCRIPTION
This commit will cover methods that were not unit tested yet. It ignores imports for coverage as most tests are ran in multiple Python version. It also fixes an except, as lists cannot throw KeyError