### PR TITLE
Fix thread context tests failing on 32-bit

### DIFF
--- a/tests/test_dom_tag.py
+++ b/tests/test_dom_tag.py
@@ -20,6 +20,8 @@ def test___get_thread_context(monkeypatch):
     assert sut._get_thread_context() in [
         -6805948436281256182, # Python >= 3.9
         3713141171098444831, # Python < 3.9
+        1692341442, # Python >= 3.9, 32-bit
+        -667720673, # Python < 3.9, 32-bit
     ]
 
 def test_add_raw_string():


### PR DESCRIPTION
Python's hash() function returns 32-bit values on 32-bit architectures; the values were acquired by running 'hash((200, 100))' on i386/alpine:edge (Python 3.11.3) and i386/alpine:3.8 (Python 3.6.9)