### PR TITLE
Add support for HTMX and Unpoly tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ print(test)
 <div data-employee="101011"></div>
 ```
 
+Similarly, use `aria_*` for [Aria](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA), `hx_*` for custom [HTMX](https://htmx.org/), and `up_*` for custom [Unpoly](https://unpoly.com/) attributes
+
 You can also modify the attributes of tags through a dictionary-like interface:
 
 ```python
@@ -158,6 +160,18 @@ print(header)
 ```
 ```html
 <div id="header"></div>
+```
+
+If attributes don't have values, you can explicitly mark them as having no value:
+
+```python
+from dominate.util import novalue
+
+link = a(href="https://url.com", up_instant=novalue(), "Click Here)
+print(link)
+```
+```html
+<a href="https://url.com" up-instant>Click Here</a>
 ```
 
 Complex Structures

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -372,8 +372,11 @@ class dom_tag(object):
     for attribute, value in sorted(self.attributes.items()):
       if value in (False, None):
         continue
-      val = unicode(value) if isinstance(value, util.text) and not value.escape else util.escape(unicode(value), True)
-      sb.append(' %s="%s"' % (attribute, val))
+      elif isinstance(value, util.novalue):
+        sb.append(' %s' % (attribute, ))
+      else:
+        val = unicode(value) if isinstance(value, util.text) and not value.escape else util.escape(unicode(value), True)
+        sb.append(' %s="%s"' % (attribute, val))
 
     sb.append(' />' if self.is_single and xhtml else '>')
 
@@ -440,12 +443,17 @@ class dom_tag(object):
       'phor': 'for',
     }.get(attribute, attribute)
 
+    # A list of attribute prefixes which mean that underscores should be converted to dashes
+    # This allows attributes like data_username or hx_post become data-username and hx-post
+    # hx_ prefix is for HTMX and up_ prefix is for Unpoly
+    SPECIAL_PREFIX_LIST = ('data_', 'aria_', 'up_', 'hx_')
+
     # Workaround for Python's reserved words
     if attribute[0] == '_':
       attribute = attribute[1:]
 
     # Workaround for dash
-    special_prefix = any([attribute.startswith(x) for x in ('data_', 'aria_')])
+    special_prefix = any([attribute.startswith(x) for x in SPECIAL_PREFIX_LIST])
     if attribute in set(['http_equiv']) or special_prefix:
       attribute = attribute.replace('_', '-').lower()
 

--- a/dominate/util.py
+++ b/dominate/util.py
@@ -184,3 +184,11 @@ def raw(s):
   Inserts a raw string into the DOM. Unsafe. Alias for text(x, escape=False)
   '''
   return text(s, escape=False)
+
+class novalue:
+  '''
+  A class to mark tag attributes as having no value.
+  important for libraries like Unpoly which require attribute values like
+  <a href="https://url.com" up-instant>Link</a>
+  '''
+  pass


### PR DESCRIPTION
This PR adds the necessary support to render HTML for the Unpoly and HTMX libraries.

The biggest change is adding `util.novalue` which can be set as the attribute of a class to make it render in HTML without a value.

It also adds `hx_` and `up_` as prefixes for attributes to be converted from underscores to dashes.