### PR TITLE
Update tests for docstring dedenting in Python 3.13

### DIFF
--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,3 +1,5 @@
+import sys
+
 import dominate.svg
 from dominate.tags import *
 from dominate.svg import *
@@ -14,7 +16,10 @@ def base():
 
 
 def get_expected(func):
-  return func.__doc__.replace('\n  ', '\n').strip()
+  doc = func.__doc__
+  if sys.version_info < (3, 13):
+      doc = doc.replace('\n  ', '\n')
+  return doc.strip()
 
 
 def output_test(func):


### PR DESCRIPTION
Update the `get_expected()` function to account for the fact that Python 3.13 automatically dedents all the docstrings, and therefore does not require explicitly removing the indent (which effectively removes too much indent).

Fixes #199