### PR TITLE
Add directives for class, style, Alpine.js, HTMX

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ Developed By
 * Tom Flanagan - <tom@zkpq.ca>
 * Jake Wharton - <jakewharton@gmail.com>
 * [Brad Janke](//github.com/bradj)
+* [Nikalexis Nikos](//github.com/nikalexis)
 
 Git repository located at
 [github.com/Knio/dominate](//github.com/Knio/dominate)
 
+Current fork (with directives feature) located at
+[github.com/nikalexis/dominate](//github.com/nikalexis/dominate)
 
 Examples
 ========
@@ -582,3 +585,174 @@ print(circle(stroke_width=5))
 <circle stroke-width="5"></circle>
 ```
 
+Using directives
+----------------
+
+Directives act as helpers to build a specific attribute of a DOM tag.
+
+Currently the following directives are available:
+
+* HTML tag attributes
+  * `class`
+  * `style`
+* Javascript magic libraries
+  * [Alpine.js](https://alpinejs.dev/start-here)
+  * [HTMX](https://htmx.org/docs/)
+
+### HTML `class` attribute examples
+
+```python
+from dominate.all import *
+
+with div('mx-3') as my_div:
+
+    # this() is a special function alias to get_current()
+    # returning always the object declared in the closest `with` clause above
+    
+    # Add / remove / reset class(es) attribute
+    my_div.klass += 'my-5' # add
+    my_div.klass('row') # reset
+    this().klass = 'row' # reset
+    this().klass.add('align-items-start') # add
+    this().klass += 'another-class' # add
+    this().klass += ('one', 'two', 'three', 'four') # add
+    this().klass -= 'another-class' # remove
+    # you can use .class_
+    this().class_.remove('one', 'two') # remove
+    # you can use .cls
+    this().cls -= ('three', 'four') # remove
+```
+
+### HTML `style` attribute examples
+
+```python
+from dominate.all import *
+
+with div('mx-3') as my_div:
+
+    # Add / remove / replace / reset style(s) attribute
+    # all underscore (_) chars are converted to hyphen (-) chars ONLY when python dict keys are used
+    # e.g. below background_color will be converted to background-color
+    this().style.add(background_color='pink', font_style='italic') # add or replace existing
+    this().style.add(color='white') # add or replace existing
+    this().style.add_extra(color='black') # add
+    this().style['font-weight'] = ('bold', '!important') # add or replace existing
+    this().style += dict(font_weight='normal') # add or replace existing
+    this().style -= 'font-weight' # remove
+    this().style.reset(font_weight='normal') # reset
+    del this().style['font-weight'] # remove
+    this().style = dict(background_color='lime') # reset
+    # underscore will not be replaced to a hyphen when is passed as a string
+    this().style['font_weight'] = 'wrong_css_hyphen' # add or replace existing
+    this().style(**{'font_weight': 'normal'}) # add or replace existing
+
+    # css property is using the ccsutils library for advanced methods
+    css = this().style.css
+    # you can do any kind of magic using this library and then set back the final css
+    css.setProperty('font-style', 'italic', 'important')
+    this().style.css = css
+```
+
+### Javascript `Alpine.js` library examples
+
+```python
+from dominate.all import *
+
+with div('mx-3') as my_div:
+
+    # Alpine.js directives
+    this().x.init = 'console.log("Testing alpine directive");'
+    # x directive is an alias to alpine
+    # you also use it as a callable
+    alpine.init('console.log("Testing alpine directive");')
+
+    with button('Click me to create an alert'):
+        # using this(). is optional for x / alpine directive
+        x.on['click'] = 'alert("Alert!");'
+        # x directive is an alias to alpine
+        alpine.on['click'] = 'alert("Alert!");'
+    
+    # all Alpine.js directives supported:
+    x.data = '...'
+    x.init = '...'
+    x.show = '...'
+    x.bind['...'] = '...'
+    x.on['...'] = '...'
+    x.text = '...'
+    x.html = '...'
+    x.model = '...'
+    x.modelable = '...'
+    x.for_ = '...'
+    x.transition = '...'
+    x.effect = '...'
+    x.ignore = '...'
+    x.ref = '...'
+    x.cloak = '...'
+    x.teleport = '...'
+    x.if_ = '...'
+    x.id = '...'
+```
+
+### Javascript `HTMX` library examples
+
+```python
+from dominate.all import *
+
+with div('mx-3') as my_div:
+
+    # HTMX directives
+    with button('Click me to replace a div using htmx'):
+        # set multiple htmx attributes together
+        this().hx.get('/replace_div/').trigger('click').target('closest .div').swap('innerHTML')
+        # hx directive is an alias to htmx
+        this().htmx.get('/replace_div_2/') # reset hx-get attribute
+        # using this(). is optional for hx / htmx directive
+        hx.swap = 'outerHTML' # reset swap
+
+    # all HTMX directives supported:
+    hx.get = '...'
+    hx.post = '...'
+    hx.on['...'] = '...'
+    hx.push_url = '...'
+    hx.select = '...'
+    hx.select_oob = '...'
+    hx.swap = '...'
+    hx.swap_oob = '...'
+    hx.target = '...'
+    hx.trigger = '...'
+    hx.vals = '...'
+
+    hx.boost = '...'
+    hx.confirm = '...'
+    hx.delete = '...'
+    hx.disable = '...'
+    hx.disable_elt = '...'
+    hx.disinherit = '...'
+    hx.encoding = '...'
+    hx.ext = '...'
+    hx.headers = '...'
+    hx.history = '...'
+    hx.history_elt = '...'
+    hx.include = '...'
+    hx.indicator = '...'
+    hx.inherit = '...'
+    hx.params = '...'
+    hx.patch = '...'
+    hx.preserve = '...'
+    hx.prompt = '...'
+    hx.put = '...'
+    hx.replace_url = '...'
+    hx.request = '...'
+    hx.sync = '...'
+    hx.validate = '...'
+    hx.vars = '...'
+```
+
+Quick imports
+-------------
+
+If you want an easy way to import all available tags, document and directives you can use the following:
+
+```python
+from dominate.all import *
+```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ For attributes `class` and `for` which conflict with Python's [reserved keywords
 |cls | fr |
 |className|htmlFor|
 |class_name|html_for|
+|klass|phor|
 
 
 ```python

--- a/dominate/all.py
+++ b/dominate/all.py
@@ -1,0 +1,3 @@
+from .document import document
+from .tags import *
+from .util import *

--- a/dominate/directives/alpine.py
+++ b/dominate/directives/alpine.py
@@ -1,0 +1,32 @@
+from .base import BaseDirective, BaseDominated, BaseModifierMixin
+
+
+class AlpineDirective(BaseDirective):
+    prefix = 'x-'
+    
+
+class AlpineModifier(BaseModifierMixin, AlpineDirective):
+    pass
+
+
+class AlpineDominated(BaseDominated):
+    default_directive = 'bind'
+
+    data = AlpineDirective()
+    init = AlpineDirective()
+    show = AlpineDirective()
+    bind = AlpineModifier()
+    on = AlpineModifier()
+    text = AlpineDirective()
+    html = AlpineDirective()
+    model = AlpineDirective()
+    modelable = AlpineDirective()
+    for_ = AlpineDirective()
+    transition = AlpineDirective()
+    effect = AlpineDirective()
+    ignore = AlpineDirective()
+    ref = AlpineDirective()
+    cloak = AlpineDirective()
+    teleport = AlpineDirective()
+    if_ = AlpineDirective()
+    id = AlpineDirective()

--- a/dominate/directives/attrs.py
+++ b/dominate/directives/attrs.py
@@ -1,0 +1,125 @@
+import cssutils
+
+from .base import BaseDirective
+
+
+class KlassDirective(BaseDirective):
+
+    def get_classes(self):
+        return [
+            c
+            for c in (self.current_attr() or '').split(' ')
+            if c != ''
+        ]
+    
+    def join_classes(self, *classes, include_current=True):
+        return " ".join(
+                self.get_classes() + list(classes) if include_current else list(classes)
+            )
+
+    def add(self, *classes):
+        return self.__call__(
+            self.join_classes(*classes)
+        )
+
+    def __add__(self, other):
+        if type(other) is str:
+            return self.join_classes(other)
+        else:
+            return self.join_classes(*other)
+
+    def remove_classes(self, *classes):
+        return self.join_classes(*[c for c in self.get_classes() if c not in classes], include_current=False)
+
+    def remove(self, *classes):
+        return self.__call__(
+            self.remove_classes(*classes)
+        )
+
+    def __sub__(self, other):
+        if type(other) is str:
+            return self.remove_classes(other)
+        else:
+            return self.remove_classes(*other)
+
+
+class StyleDirective(BaseDirective):
+
+    encoding='utf-8'
+    normalize = True
+
+    @property
+    def css(self):
+        return cssutils.parseStyle(self.current_attr() or '', self.encoding)
+
+    @css.setter
+    def css(self, css):
+        super().__call__(css.getCssText(' '))
+
+    def reset_style(self, **properties):
+        return self.make_style(False, **properties)
+
+    def make_style(self, __include_current=True, __replace=True, __is_pythonic_key=True, **properties):
+        css = self.css if __include_current else cssutils.css.CSSStyleDeclaration()
+
+        for name, value in properties.items():
+            value, priority = value if type(value) is tuple else (value, '')
+
+            if __is_pythonic_key:
+                name = name.replace('_', '-')
+
+            css.setProperty(name, value, priority, self.normalize, __replace)
+        
+        return css.getCssText(' ')
+    
+    def reset(self, **properties):
+        return super().__call__(
+            self.reset_style(**properties)
+        )
+
+    def add(self, __replace=True, **properties):
+        return super().__call__(
+            self.make_style(True, __replace, **properties)
+        )
+
+    def add_extra(self, **properties):
+        return self.add(False, **properties)
+
+    def __add__(self, other):
+        return self.make_style(True, True, **other)
+
+    def __setitem__(self, key, value):
+        return super().__call__(
+            self.make_style(True, True, False, **{key: value})
+        )
+
+    def __set__(self, instance, value):
+        if type(value) is dict:
+            self.__call__(**value)
+        elif type(value) is cssutils.css.CSSStyleDeclaration:
+            super().__call__(value.getCssText(' '))
+        else:
+            super().__call__(value)
+
+    def remove_properties(self, *properties):
+        css = self.css
+
+        for name in properties:
+            css.removeProperty(name, self.normalize)
+        
+        return css.getCssText(' ')
+    
+    def remove(self, *properties):
+        return super().__call__(self.remove_properties(*properties))
+
+    def __delitem__(self, key):
+        return self.remove(key)
+
+    def __sub__(self, other):
+        if type(other) is str:
+            return self.remove_properties(other)
+        else:
+            return self.remove_properties(*other)
+
+    def __call__(self, **properties):
+        super().__call__(self.reset_style(**properties))

--- a/dominate/directives/base.py
+++ b/dominate/directives/base.py
@@ -1,0 +1,115 @@
+from copy import copy
+
+
+class DescriptorMixin:
+    instance = None
+
+    descriptor_name = None
+    fixed_name = None
+
+    fix_endswith_underscore = True
+    fix_hyphen = True
+
+    def __set_name__(self, owner, name):
+        self.descriptor_name = name
+
+        fixed_name = name
+
+        if self.fix_endswith_underscore and fixed_name.endswith('_'):
+            fixed_name = fixed_name[0:-1]
+        
+        if self.fix_hyphen:
+            fixed_name = fixed_name.replace('_', '-')
+
+        self.fixed_name = fixed_name
+
+    def __get__(self, instance, owner):
+        copied_self = copy(self)
+        copied_self.instance = instance
+        return instance.__dict__.setdefault(
+            '__' + self.descriptor_name,
+            copied_self,
+        )
+
+    def __set__(self, instance, value):
+        self.__call__(value)
+
+
+class BaseDominated(DescriptorMixin):
+
+    default_directive = None
+
+    def __getitem__(self, key):
+        if self.default_directive:
+            return getattr(self, self.default_directive)[key]
+        else:
+            raise NotImplementedError(f"`{self.__class__.__name__}` does not support a default directive.")
+
+    def __setitem__(self, key, value):
+        if self.default_directive:
+            return getattr(self, self.default_directive)[key](value)
+        else:
+            raise NotImplementedError(f"`{self.__class__.__name__}` does not support a default directive.")
+
+    def __call__(self, value):
+        if self.default_directive:
+            return getattr(self, self.default_directive)(value)
+        else:
+            raise NotImplementedError(f"`{self.__class__.__name__}` does not support a default directive.")
+
+
+class BaseDirective(DescriptorMixin):
+    
+    prefix = ''
+    
+    @property
+    def directive(self):
+        return self.fixed_name
+
+    def full_directive(self):
+        return f"{self.prefix}{self.directive}"
+
+    def make_attr(self, value):
+        return {
+            self.full_directive(): value
+        }
+
+    def current_attr(self):
+        from ..dom_tag import get_current, dom_tag
+        return (self.instance if isinstance(self.instance, dom_tag) else get_current()).attributes.get(self.full_directive(), None)
+
+    def __call__(self, value):
+        from ..dom_tag import attr, dom_tag
+        attributes = self.make_attr(value)
+        if isinstance(self.instance, dom_tag):
+            for attribute, value in attributes.items():
+                self.instance.set_attribute(*dom_tag.clean_pair(attribute, value))
+        else:
+            attr(**attributes)
+        return self.instance
+
+
+class BaseModifierMixin:
+
+    separator = ":"
+    modifier = None
+
+    def __getitem__(self, key):
+        self.modifier = key
+        return self
+
+    def __setitem__(self, key, value):
+        self.modifier = key
+        self.__call__(value)
+        return self
+
+    def make_attr(self, value):
+        attr = super().make_attr(value)
+        
+        if self.modifier:
+            attr = {
+                f"{key}{self.separator}{self.modifier}": value
+                for key, value in attr.items()
+            }
+        
+        return attr

--- a/dominate/directives/htmx.py
+++ b/dominate/directives/htmx.py
@@ -1,0 +1,50 @@
+from .base import BaseDirective, BaseDominated, BaseModifierMixin
+
+
+class HtmxDirective(BaseDirective):
+    prefix = 'hx-'
+    
+
+class HtmxModifier(BaseModifierMixin, HtmxDirective):
+    pass
+
+
+class HtmxDominated(BaseDominated):
+    default_directive = 'on'
+
+    get = HtmxDirective()
+    post = HtmxDirective()
+    on = HtmxModifier()
+    push_url = HtmxDirective()
+    select = HtmxDirective()
+    select_oob = HtmxDirective()
+    swap = HtmxDirective()
+    swap_oob = HtmxDirective()
+    target = HtmxDirective()
+    trigger = HtmxDirective()
+    vals = HtmxDirective()
+
+    boost = HtmxDirective()
+    confirm = HtmxDirective()
+    delete = HtmxDirective()
+    disable = HtmxDirective()
+    disable_elt = HtmxDirective()
+    disinherit = HtmxDirective()
+    encoding = HtmxDirective()
+    ext = HtmxDirective()
+    headers = HtmxDirective()
+    history = HtmxDirective()
+    history_elt = HtmxDirective()
+    include = HtmxDirective()
+    indicator = HtmxDirective()
+    inherit = HtmxDirective()
+    params = HtmxDirective()
+    patch = HtmxDirective()
+    preserve = HtmxDirective()
+    prompt = HtmxDirective()
+    put = HtmxDirective()
+    replace_url = HtmxDirective()
+    request = HtmxDirective()
+    sync = HtmxDirective()
+    validate = HtmxDirective()
+    vars = HtmxDirective()

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -27,6 +27,10 @@ from asyncio import get_event_loop
 from uuid import uuid4
 from contextvars import ContextVar
 
+from .directives.attrs import KlassDirective, StyleDirective
+from .directives.alpine import AlpineDominated
+from .directives.htmx import HtmxDominated
+
 try:
   # Python 3
   from collections.abc import Callable
@@ -86,6 +90,11 @@ class dom_tag(object):
                      # modified
   is_inline = False
 
+  klass = cls = class_ = KlassDirective()
+  style = StyleDirective()
+
+  alpine = x = AlpineDominated()
+  htmx = hx = HtmxDominated()
 
   def __new__(_cls, *args, **kwargs):
     '''

--- a/dominate/tags.py
+++ b/dominate/tags.py
@@ -1130,3 +1130,13 @@ class comment(html_tag):
     sb.append('>')
 
     return sb
+
+
+# Templating
+class template(html_tag):
+  '''
+  The template element serves as a mechanism for holding HTML fragments,
+  which can either be used later via JavaScript or generated immediately into shadow DOM.
+  The template element represents a browser-based template object in a html, that is not rendered.
+  '''
+  pass

--- a/dominate/util.py
+++ b/dominate/util.py
@@ -22,7 +22,10 @@ Public License along with Dominate.  If not, see
 
 import re
 
-from .dom_tag import dom_tag
+from .directives.alpine import AlpineDominated
+from .directives.htmx import HtmxDominated
+
+from .dom_tag import dom_tag, get_current
 
 try:
   basestring = basestring
@@ -184,3 +187,10 @@ def raw(s):
   Inserts a raw string into the DOM. Unsafe. Alias for text(x, escape=False)
   '''
   return text(s, escape=False)
+
+
+this = get_current
+
+alpine = x = AlpineDominated()
+
+htmx = hx = HtmxDominated()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: HTML",
 ]
 dynamic = ["version"]
+dependencies = [
+    'cssutils >= 2.11.1',
+]
 
 [project.urls]
 Homepage = "https://github.com/Knio/dominate"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ license_files = ["LICENSE.txt"]
 
 [bdist_wheel]
 universal=1
+
+[options]
+install_requires =
+    cssutils >= 2.11.1

--- a/setup/setup.py
+++ b/setup/setup.py
@@ -57,7 +57,9 @@ setup(
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Text Processing :: Markup :: HTML',
   ],
-
+  install_requires=[
+    'cssutils >= 2.11.1',
+  ],
   packages = ['dominate'],
   include_package_data = True,
 )


### PR DESCRIPTION
Hi, thank you for providing this awesome library!

I have enriched the library, so any developer can user some helpers for building common HTML attributes (class, style as a start), but also some powerful javascript libraries that are based on setting special HTML attributes (Alpine.js, HTMX).

You can have a look in the updated [README.md / Using directives](https://github.com/nikalexis/dominate/tree/directives-rc-1.0.0?tab=readme-ov-file#using-directives) for code examples using the new features.

In case you think this is a good idea, I will be glad to discuss any guidelines you have in order to accept it in your master (upstream) branch / release cycle.