### PR TITLE
Add reference to JavaScript functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ print(d)
 Embedding HTML
 --------------
 
-If you need to embed a node of pre-formed HTML coming from a library such as markdown or the like, you can avoid escaped HTML by using the raw method from the dominate.util package:
+If you need to embed a node of pre-formed HTML coming from a library such as markdown or the like you can avoid escaped HTML by using the raw method from the dominate.util package:
 
 ```
 from dominate.util import raw
@@ -564,7 +564,7 @@ from dominate.util import raw
 td(raw('<a href="example.html">Example</a>'))
 ```
 
-Without the raw call, this code would render escaped HTML with lt, etc.
+Without the raw call, this code would render escaped HTML with lt, etc. The behavior of the previous block of code is the same as `td_element.innerHTML="<a href="example.html">Example</a>"` in JavaScript.
 
 
 SVG


### PR DESCRIPTION
Since the functionality of `dominate.util.raw` is practically the same as the [`element.innerHTML` in JavaScript](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML), and this is very widespread in the "HTML community", I think it is a good idea to provide this reference in the documentation for people doing `ctrl`+`f`←`innerhtml` in their browsers looking for this functionality.