### PR TITLE
Replace get_event_loop() with get_running_loop() for asyncio compatibility

### DIFF
--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -23,7 +23,7 @@ import numbers
 from collections import defaultdict, namedtuple
 from functools import wraps
 import threading
-from asyncio import get_event_loop
+from asyncio import get_running_loop
 from uuid import uuid4
 from contextvars import ContextVar
 
@@ -71,7 +71,7 @@ def _get_thread_context():
     context.append(("greenlet", greenlet.getcurrent()))
 
   try:
-    if get_event_loop().is_running():
+    if get_running_loop().is_running():
       # Only add this extra information if we are actually in a running event loop
       context.append(("async", _get_async_context_id()))
   # A runtime error is raised if there is no async loop...


### PR DESCRIPTION
Hello,

I got `DeprecationWarning: There is no current event loop` when using `dominate v2.9.1`  with Python 3.10 or newer.
ref: https://github.com/thombashi/pytablewriter/issues/66

According to the [official Python 3.10 document](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop):

> In Python versions 3.10.0–3.10.8 and 3.11.0 this function (and other functions which use it implicitly) emitted a DeprecationWarning if there was no running event loop, even if the current loop was set on the policy. In Python versions 3.10.9, 3.11.1 and 3.12 they emit a DeprecationWarning if there is no running event loop and no current loop is set. In some future Python release this will become an error.

And it was [deprecated in Python 3.12](https://docs.python.org/3.13/library/asyncio-eventloop.html#asyncio.get_event_loop):

>Deprecated since version 3.12: Deprecation warning is emitted if there is no current event loop. In some future Python release this will become an error.

The document suggests using the `get_running_loop()` function instead of `get_event_loop()` function.

This will resolve: https://github.com/Knio/dominate/issues/198
