### PR TITLE
Add __slots__ to minimize memory usage

### DIFF
--- a/dominate/community/htmx.py
+++ b/dominate/community/htmx.py
@@ -2,6 +2,7 @@
 from .. import tags
 
 class HtmxTag:
+  __slots__ = ()
   @classmethod
   def clean_attribute(cls, attribute):
     attribute = super().clean_attribute(attribute)

--- a/dominate/document.py
+++ b/dominate/document.py
@@ -26,6 +26,8 @@ except NameError: # py3
   unicode = str
 
 class document(tags.html):
+  __slots__ = ('doctype', 'title_node', 'head', 'body', 'header',
+    'main', 'footer', '_entry')
   tagname = 'html'
   def __init__(self, title='Dominate', doctype='<!DOCTYPE html>', *a, **kw):
     '''

--- a/dominate/dom1core.py
+++ b/dominate/dom1core.py
@@ -30,6 +30,8 @@ class dom1core(object):
   http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/
   http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html
   '''
+  __slots__ = ()
+
   @property
   def parentNode(self):
     '''

--- a/dominate/dom_tag.py
+++ b/dominate/dom_tag.py
@@ -80,6 +80,7 @@ def _get_thread_context():
   return tuple(context)
 
 class dom_tag(object):
+  __slots__ = ('attributes', 'children', 'parent', '_ctx')
   is_single = False  # Tag does not require matching end tag (ex. <hr/>)
   is_pretty = True   # Text inside the tag should be left as-is (ex. <pre>)
                      # otherwise, text will be escaped() and whitespace may be
@@ -121,8 +122,8 @@ class dom_tag(object):
     self.parent     = None
 
     # Does not insert newlines on all children if True (recursive attribute)
-    self.is_inline = kwargs.pop('__inline', self.is_inline)
-    self.is_pretty = kwargs.pop('__pretty', self.is_pretty)
+    #self.is_inline = kwargs.pop('__inline', self.is_inline)
+    #self.is_pretty = kwargs.pop('__pretty', self.is_pretty)
 
     #Add child elements
     if args:

--- a/dominate/svg.py
+++ b/dominate/svg.py
@@ -4,8 +4,6 @@ This module consists of classes specific to HTML5-SVG Elements. In general this 
 - Elements that are deprecated
 '''
 from dominate.tags import html_tag
-from dominate.dom_tag import dom_tag
-import numbers
 
 
 __license__ = '''
@@ -48,9 +46,9 @@ _ATTR_EVENTS = set([
 ])
 
 DASHED_ATTRIBUTES = set([
-  'accent', 'alignment', 'arabic', 'baseline', 'cap', 'clip', 'color', 'dominant', 'enable', 'fill', 'flood', 
-  'font', 'glyph', 'horiz', 'image', 'letter', 'lighting', 'marker', 'overline', 'paint', 'panose', 'pointer', 
-  'rendering', 'shape', 'stop', 'strikethrough', 'stroke', 'text', 'underline', 'unicode', 'units', 'v', 'vector', 
+  'accent', 'alignment', 'arabic', 'baseline', 'cap', 'clip', 'color', 'dominant', 'enable', 'fill', 'flood',
+  'font', 'glyph', 'horiz', 'image', 'letter', 'lighting', 'marker', 'overline', 'paint', 'panose', 'pointer',
+  'rendering', 'shape', 'stop', 'strikethrough', 'stroke', 'text', 'underline', 'unicode', 'units', 'v', 'vector',
   'vert', 'word', 'writing', 'x'
 ])
 

--- a/dominate/tags.py
+++ b/dominate/tags.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General
 Public License along with Dominate.  If not, see
 <http://www.gnu.org/licenses/>.
 '''
-from .dom_tag  import dom_tag, attr, get_current
+from .dom_tag  import dom_tag
 from .dom1core import dom1core
 
 try:
@@ -56,11 +56,13 @@ ERR_CONTENT = 'content'
 
 
 class html_tag(dom_tag, dom1core):
+  __slots__ = ()
+
   def __init__(self, *args, **kwargs):
     '''
     Creates a new html tag instance.
     '''
-    super(html_tag, self).__init__(*args, **kwargs)
+    super().__init__(*args, **kwargs)
 
 
   # def validate(self):
@@ -115,7 +117,7 @@ class html(html_tag):
   '''
   The html element represents the root of an HTML document.
   '''
-  pass
+  __slots__ = ()
   # def validate_attributes(self):
   #   errors = []
   #   for invalid in self._check_attributes(_ATTR_GLOBAL, 'manifest'):
@@ -138,7 +140,7 @@ class head(html_tag):
   '''
   The head element represents a collection of metadata for the document.
   '''
-  pass
+  __slots__ = ()
 
 
 class title(html_tag):
@@ -207,7 +209,6 @@ class noscript(html_tag):
   different markup to user agents that support scripting and those that don't
   support scripting, by affecting how the document is parsed.
   '''
-  pass
 
 
 # Sections
@@ -215,7 +216,6 @@ class body(html_tag):
   '''
   The body element represents the main content of the document.
   '''
-  pass
 
 class main(html_tag):
   '''
@@ -232,7 +232,6 @@ class section(html_tag):
   application. A section, in this context, is a thematic grouping of content,
   typically with a heading.
   '''
-  pass
 
 
 class nav(html_tag):
@@ -240,7 +239,6 @@ class nav(html_tag):
   The nav element represents a section of a page that links to other pages or
   to parts within the page: a section with navigation links.
   '''
-  pass
 
 
 class article(html_tag):
@@ -251,7 +249,6 @@ class article(html_tag):
   magazine or newspaper article, a blog entry, a user-submitted comment, an
   interactive widget or gadget, or any other independent item of content.
   '''
-  pass
 
 
 class aside(html_tag):
@@ -261,49 +258,42 @@ class aside(html_tag):
   which could be considered separate from that content. Such sections are
   often represented as sidebars in printed typography.
   '''
-  pass
 
 
 class h1(html_tag):
   '''
   Represents the highest ranking heading.
   '''
-  pass
 
 
 class h2(html_tag):
   '''
   Represents the second-highest ranking heading.
   '''
-  pass
 
 
 class h3(html_tag):
   '''
   Represents the third-highest ranking heading.
   '''
-  pass
 
 
 class h4(html_tag):
   '''
   Represents the fourth-highest ranking heading.
   '''
-  pass
 
 
 class h5(html_tag):
   '''
   Represents the fifth-highest ranking heading.
   '''
-  pass
 
 
 class h6(html_tag):
   '''
   Represents the sixth-highest ranking heading.
   '''
-  pass
 
 
 class hgroup(html_tag):
@@ -312,14 +302,12 @@ class hgroup(html_tag):
   to group a set of h1-h6 elements when the heading has multiple levels, such
   as subheadings, alternative titles, or taglines.
   '''
-  pass
 
 
 class header(html_tag):
   '''
   The header element represents a group of introductory or navigational aids.
   '''
-  pass
 
 
 class footer(html_tag):
@@ -329,7 +317,6 @@ class footer(html_tag):
   about its section such as who wrote it, links to related documents,
   copyright data, and the like.
   '''
-  pass
 
 
 class address(html_tag):
@@ -338,7 +325,6 @@ class address(html_tag):
   article or body element ancestor. If that is the body element, then the
   contact information applies to the document as a whole.
   '''
-  pass
 
 
 # Grouping content
@@ -346,7 +332,6 @@ class p(html_tag):
   '''
   The p element represents a paragraph.
   '''
-  pass
 
 
 class hr(html_tag):
@@ -371,7 +356,6 @@ class blockquote(html_tag):
   The blockquote element represents a section that is quoted from another
   source.
   '''
-  pass
 
 
 class ol(html_tag):
@@ -380,7 +364,6 @@ class ol(html_tag):
   intentionally ordered, such that changing the order would change the
   meaning of the document.
   '''
-  pass
 
 
 class ul(html_tag):
@@ -389,7 +372,6 @@ class ul(html_tag):
   not important - that is, where changing the order would not materially change
   the meaning of the document.
   '''
-  pass
 
 
 class li(html_tag):
@@ -399,7 +381,6 @@ class li(html_tag):
   defined for those elements. Otherwise, the list item has no defined
   list-related relationship to any other li element.
   '''
-  pass
 
 
 class dl(html_tag):
@@ -410,7 +391,6 @@ class dl(html_tag):
   Within a single dl element, there should not be more than one dt element for
   each name.
   '''
-  pass
 
 
 class dt(html_tag):
@@ -418,7 +398,6 @@ class dt(html_tag):
   The dt element represents the term, or name, part of a term-description group
   in a description list (dl element).
   '''
-  pass
 
 
 class dd(html_tag):
@@ -426,7 +405,6 @@ class dd(html_tag):
   The dd element represents the description, definition, or value, part of a
   term-description group in a description list (dl element).
   '''
-  pass
 
 
 class figure(html_tag):
@@ -435,7 +413,6 @@ class figure(html_tag):
   that is self-contained and is typically referenced as a single unit from the
   main flow of the document.
   '''
-  pass
 
 
 class figcaption(html_tag):
@@ -443,7 +420,6 @@ class figcaption(html_tag):
   The figcaption element represents a caption or legend for the rest of the
   contents of the figcaption element's parent figure element, if any.
   '''
-  pass
 
 
 class div(html_tag):
@@ -452,7 +428,6 @@ class div(html_tag):
   can be used with the class, lang, and title attributes to mark up semantics
   common to a group of consecutive elements.
   '''
-  pass
 
 
 # Text semantics
@@ -465,28 +440,24 @@ class a(html_tag):
   placeholder for where a link might otherwise have been placed, if it had been
   relevant.
   '''
-  pass
 
 
 class em(html_tag):
   '''
   The em element represents stress emphasis of its contents.
   '''
-  pass
 
 
 class strong(html_tag):
   '''
   The strong element represents strong importance for its contents.
   '''
-  pass
 
 
 class small(html_tag):
   '''
   The small element represents side comments such as small print.
   '''
-  pass
 
 
 class s(html_tag):
@@ -494,7 +465,6 @@ class s(html_tag):
   The s element represents contents that are no longer accurate or no longer
   relevant.
   '''
-  pass
 
 
 class cite(html_tag):
@@ -506,14 +476,12 @@ class cite(html_tag):
   quoted or referenced in detail (i.e. a citation), or it can just be a work
   that is mentioned in passing.
   '''
-  pass
 
 
 class q(html_tag):
   '''
   The q element represents some phrasing content quoted from another source.
   '''
-  pass
 
 
 class dfn(html_tag):
@@ -523,7 +491,6 @@ class dfn(html_tag):
   element must also contain the definition(s) for the term given by the dfn
   element.
   '''
-  pass
 
 
 class abbr(html_tag):
@@ -533,7 +500,6 @@ class abbr(html_tag):
   abbreviation. The attribute, if specified, must contain an expansion of the
   abbreviation, and nothing else.
   '''
-  pass
 
 
 class time_(html_tag):
@@ -542,7 +508,6 @@ class time_(html_tag):
   date in the proleptic Gregorian calendar, optionally with a time and a
   time-zone offset.
   '''
-  pass
 _time = time_
 
 
@@ -552,7 +517,6 @@ class code(html_tag):
   element name, a filename, a computer program, or any other string that a
   computer would recognize.
   '''
-  pass
 
 
 class var(html_tag):
@@ -562,7 +526,6 @@ class var(html_tag):
   constant, a function parameter, or just be a term used as a placeholder in
   prose.
   '''
-  pass
 
 
 class samp(html_tag):
@@ -570,7 +533,6 @@ class samp(html_tag):
   The samp element represents (sample) output from a program or computing
   system.
   '''
-  pass
 
 
 class kbd(html_tag):
@@ -578,14 +540,12 @@ class kbd(html_tag):
   The kbd element represents user input (typically keyboard input, although it
   may also be used to represent other input, such as voice commands).
   '''
-  pass
 
 
 class sub(html_tag):
   '''
   The sub element represents a subscript.
   '''
-  pass
 
 
 class sup(html_tag):
@@ -593,7 +553,6 @@ class sup(html_tag):
   '''
   The sup element represents a superscript.
   '''
-  pass
 
 
 class i(html_tag):
@@ -605,7 +564,6 @@ class i(html_tag):
   idiomatic phrase from another language, a thought, or a ship name in Western
   texts.
   '''
-  pass
 
 
 class b(html_tag):
@@ -616,7 +574,6 @@ class b(html_tag):
   abstract, product names in a review, actionable words in interactive
   text-driven software, or an article lede.
   '''
-  pass
 
 
 class u(html_tag):
@@ -626,7 +583,6 @@ class u(html_tag):
   being a proper name in Chinese text (a Chinese proper name mark), or
   labeling the text as being misspelt.
   '''
-  pass
 
 
 class mark(html_tag):
@@ -642,7 +598,6 @@ class mark(html_tag):
   document that has been highlighted due to its likely relevance to the user's
   current activity.
   '''
-  pass
 
 
 class ruby(html_tag):
@@ -653,14 +608,12 @@ class ruby(html_tag):
   pronunciation or to include other annotations. In Japanese, this form of
   typography is also known as furigana.
   '''
-  pass
 
 
 class rt(html_tag):
   '''
   The rt element marks the ruby text component of a ruby annotation.
   '''
-  pass
 
 
 class rp(html_tag):
@@ -669,7 +622,6 @@ class rp(html_tag):
   component of a ruby annotation, to be shown by user agents that don't support
   ruby annotations.
   '''
-  pass
 
 
 class bdi(html_tag):
@@ -677,7 +629,6 @@ class bdi(html_tag):
   The bdi element represents a span of text that is to be isolated from its
   surroundings for the purposes of bidirectional text formatting.
   '''
-  pass
 
 
 class bdo(html_tag):
@@ -686,7 +637,6 @@ class bdo(html_tag):
   for its children. It allows authors to override the Unicode bidirectional
   algorithm by explicitly specifying a direction override.
   '''
-  pass
 
 
 class span(html_tag):
@@ -695,7 +645,6 @@ class span(html_tag):
   used together with the global attributes, e.g. class, lang, or dir. It
   represents its children.
   '''
-  pass
 
 
 class br(html_tag):
@@ -719,14 +668,12 @@ class ins(html_tag):
   '''
   The ins element represents an addition to the document.
   '''
-  pass
 
 
 class del_(html_tag):
   '''
   The del element represents a removal from the document.
   '''
-  pass
 _del = del_
 
 # Embedded content
@@ -741,7 +688,6 @@ class iframe(html_tag):
   '''
   The iframe element represents a nested browsing context.
   '''
-  pass
 
 
 class embed(html_tag):
@@ -758,7 +704,6 @@ class object_(html_tag):
   the type of the resource, will either be treated as an image, as a nested
   browsing context, or as an external resource to be processed by a plugin.
   '''
-  pass
 _object = object_
 
 
@@ -775,14 +720,12 @@ class video(html_tag):
   A video element is used for playing videos or movies, and audio files with
   captions.
   '''
-  pass
 
 
 class audio(html_tag):
   '''
   An audio element represents a sound or audio stream.
   '''
-  pass
 
 
 class source(html_tag):
@@ -807,7 +750,6 @@ class canvas(html_tag):
   canvas, which can be used for rendering graphs, game graphics, or other
   visual images on the fly.
   '''
-  pass
 
 
 class map_(html_tag):
@@ -815,7 +757,6 @@ class map_(html_tag):
   The map element, in conjunction with any area element descendants, defines an
   image map. The element represents its children.
   '''
-  pass
 _map = map_
 
 class area(html_tag):
@@ -832,7 +773,6 @@ class table(html_tag):
   The table element represents data with more than one dimension, in the form
   of a table.
   '''
-  pass
 
 
 class caption(html_tag):
@@ -840,7 +780,6 @@ class caption(html_tag):
   The caption element represents the title of the table that is its parent, if
   it has a parent and that is a table element.
   '''
-  pass
 
 
 class colgroup(html_tag):
@@ -848,7 +787,6 @@ class colgroup(html_tag):
   The colgroup element represents a group of one or more columns in the table
   that is its parent, if it has a parent and that is a table element.
   '''
-  pass
 
 
 class col(html_tag):
@@ -866,7 +804,6 @@ class tbody(html_tag):
   for the parent table element, if the tbody element has a parent and it is a
   table.
   '''
-  pass
 
 
 class thead(html_tag):
@@ -875,7 +812,6 @@ class thead(html_tag):
   labels (headers) for the parent table element, if the thead element has a
   parent and it is a table.
   '''
-  pass
 
 
 class tfoot(html_tag):
@@ -884,28 +820,24 @@ class tfoot(html_tag):
   summaries (footers) for the parent table element, if the tfoot element has a
   parent and it is a table.
   '''
-  pass
 
 
 class tr(html_tag):
   '''
   The tr element represents a row of cells in a table.
   '''
-  pass
 
 
 class td(html_tag):
   '''
   The td element represents a data cell in a table.
   '''
-  pass
 
 
 class th(html_tag):
   '''
   The th element represents a header cell in a table.
   '''
-  pass
 
 
 # Forms
@@ -915,7 +847,6 @@ class form(html_tag):
   which can represent editable values that can be submitted to a server for
   processing.
   '''
-  pass
 
 
 class fieldset(html_tag):
@@ -923,7 +854,6 @@ class fieldset(html_tag):
   The fieldset element represents a set of form controls optionally grouped
   under a common name.
   '''
-  pass
 
 
 class legend(html_tag):
@@ -931,7 +861,6 @@ class legend(html_tag):
   The legend element represents a caption for the rest of the contents of the
   legend element's parent fieldset element, if any.
   '''
-  pass
 
 
 class label(html_tag):
@@ -941,7 +870,6 @@ class label(html_tag):
   control, either using for attribute, or by putting the form control inside
   the label element itself.
   '''
-  pass
 
 
 class input_(html_tag):
@@ -958,7 +886,6 @@ class button(html_tag):
   The button element represents a button. If the element is not disabled, then
   the user agent should allow the user to activate the button.
   '''
-  pass
 
 
 class select(html_tag):
@@ -966,7 +893,6 @@ class select(html_tag):
   The select element represents a control for selecting amongst a set of
   options.
   '''
-  pass
 
 
 class datalist(html_tag):
@@ -977,7 +903,6 @@ class datalist(html_tag):
   represent the predefined options. In the rendering, the datalist element
   represents nothing and it, along with its children, should be hidden.
   '''
-  pass
 
 
 class optgroup(html_tag):
@@ -985,7 +910,6 @@ class optgroup(html_tag):
   The optgroup element represents a group of option elements with a common
   label.
   '''
-  pass
 
 
 class option(html_tag):
@@ -993,7 +917,6 @@ class option(html_tag):
   The option element represents an option in a select element or as part of a
   list of suggestions in a datalist element.
   '''
-  pass
 
 
 class textarea(html_tag):
@@ -1002,7 +925,6 @@ class textarea(html_tag):
   element's raw value. The contents of the control represent the control's
   default value.
   '''
-  pass
 
 
 class keygen(html_tag):
@@ -1018,7 +940,6 @@ class output(html_tag):
   '''
   The output element represents the result of a calculation.
   '''
-  pass
 
 
 class progress(html_tag):
@@ -1030,7 +951,6 @@ class progress(html_tag):
   the progress is a number in the range zero to a maximum, giving the fraction
   of work that has so far been completed.
   '''
-  pass
 
 
 class meter(html_tag):
@@ -1039,7 +959,6 @@ class meter(html_tag):
   fractional value; for example disk usage, the relevance of a query result, or
   the fraction of a voting population to have selected a particular candidate.
   '''
-  pass
 
 
 # Interactive elements
@@ -1048,7 +967,6 @@ class details(html_tag):
   The details element represents a disclosure widget from which the user can
   obtain additional information or controls.
   '''
-  pass
 
 
 class summary(html_tag):
@@ -1056,7 +974,6 @@ class summary(html_tag):
   The summary element represents a summary, caption, or legend for the rest of
   the contents of the summary element's parent details element, if any.
   '''
-  pass
 
 
 class command(html_tag):
@@ -1070,14 +987,12 @@ class menu(html_tag):
   '''
   The menu element represents a list of commands.
   '''
-  pass
 
 
 class font(html_tag):
   '''
   The font element represents the font in a html .
   '''
-  pass
 
 
 # Additional markup

--- a/dominate/util.py
+++ b/dominate/util.py
@@ -124,6 +124,7 @@ class container(dom_tag):
   '''
   Contains multiple elements, but does not add a level
   '''
+  __slots__ = ()
   is_inline = True
   def _render(self, sb, indent_level, indent_str, pretty, xhtml):
     inline = self._render_children(sb, indent_level, indent_str, pretty, xhtml)
@@ -137,6 +138,8 @@ class lazy(dom_tag):
   '''
   delays function execution until rendered
   '''
+  __slots__ = ()
+
   def __new__(_cls, *args, **kwargs):
     '''
     Need to reset this special method or else
@@ -163,6 +166,7 @@ class text(dom_tag):
   '''
   Just a string. Useful for inside context managers
   '''
+  __slots__ = ('escape', 'text')
   is_pretty = False
   is_inline = True
 


### PR DESCRIPTION
Add __slots__ makes python not to instantiate a dict for each object which improves memory usage.

This is specially important with applications that create a large number of tags.

The only issue with __slots__ is that one cannot have a class attribute that has the same name as an object attribute. This causes an issue with is_inline and is_pretty.

In the current patch I simply commented the code that allows to change those attributes in a given object instance (it can be declared at class-level only), but it can be solved either by renaming `is_inline` with simply `inline` at class-level or object-level.

I can implement either one or the other, I don't care, but of course any of those changes means a backwards compatibility issue. Who do we want to annoy: those declaring new classes or those redefining `is_inline` and `is_pretty` on object instantiation?

Apart from the slots, which I could verify that really reduce the memory footprint, I did some minor changes cosmetic changes which I can revert.