### PR TITLE
Add support for Python 3.14, drop EOL 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
        python: ["3"]
        os: ["ubuntu-latest"]
        include:
-          - {python: "3.9", os: "ubuntu-22.04"}
           - {python: "3.10", os: "ubuntu-22.04"}
           - {python: "3.11", os: "ubuntu-22.04"}
           - {python: "3.12", os: "ubuntu-22.04"}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Dominate
-on:
-  push:
-    branches: ["master"]
-  pull_request:
-    branches: ["master"]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
@@ -24,9 +20,9 @@ jobs:
           - {python: "3.13", os: "ubuntu-24.04"}
           - {python: "pypy3.10", os: "ubuntu-24.04"}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: "Set up Python ${{ matrix.python }}"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
     - name: "Install dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - {python: "3.11", os: "ubuntu-22.04"}
           - {python: "3.12", os: "ubuntu-22.04"}
           - {python: "3.13", os: "ubuntu-24.04"}
+          - {python: "3.14", os: "ubuntu-24.04"}
           - {python: "pypy3.10", os: "ubuntu-24.04"}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - {python: "3.12", os: "ubuntu-22.04"}
           - {python: "3.13", os: "ubuntu-24.04"}
           - {python: "3.14", os: "ubuntu-24.04"}
-          - {python: "pypy3.10", os: "ubuntu-24.04"}
+          - {python: "pypy3.11", os: "ubuntu-24.04"}
     steps:
     - uses: actions/checkout@v6
     - name: "Set up Python ${{ matrix.python }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Tom Flanagan", email = "tom@zkpq.ca"},
     {name = "Jake Wharton"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["framework", "templating", "template", "html", "xhtml", "python", "html5"]
 license = {text = "LGPL-3.0-or-newer"}
 classifiers = [
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [metadata]
 license_files = ["LICENSE.txt"]
-
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
https://devguide.python.org/versions/

---

Also it would be great to get a release at some point: the last was Dec 2023 and it'd be nice to get rid of the deprecation warning fixed in Dec 2024: https://github.com/Knio/dominate/pull/211. Thanks!